### PR TITLE
[FIX] Minimap icon position when UI is scaled

### DIFF
--- a/ui/StoryTellerButton.lua
+++ b/ui/StoryTellerButton.lua
@@ -11,13 +11,14 @@ function StoryTellerButton.Reposition()
 end
 
 function StoryTellerButton.DraggingFrame_OnUpdate()
-	local xpos,ypos = GetCursorPosition()
-	local xmin,ymin = Minimap:GetLeft() + Minimap:GetWidth() / 2, Minimap:GetBottom() + Minimap:GetHeight() / 2
+	local xpos, ypos = GetCursorPosition()
+	local xmin, ymin = Minimap:GetCenter()
+	local scale = UIParent:GetScale()
 
-	xpos = xpos-xmin/UIParent:GetScale()
-	ypos = ypos-ymin/UIParent:GetScale()
+	xpos = xpos / scale
+	ypos = ypos / scale
 
-	StoryTeller_Settings.minimapPosition = math.deg(math.atan2(ypos,xpos))
+	StoryTeller_Settings.minimapPosition = math.deg(math.atan2(ypos - ymin, xpos - xmin)) % 360
 	StoryTellerButton.Reposition()
 end
 
@@ -84,4 +85,3 @@ end
 function StoryTellerButton.HideTooltip()
 	GameTooltip:Hide();
 end
-


### PR DESCRIPTION
When the UI is scaled, the icon button can't be moved
This fix it for round minimap.
It can be easier to manage it with [libdbicon-1-0](https://www.curseforge.com/wow/addons/libdbicon-1-0)